### PR TITLE
[Feature] Optionally exclude debug logging from object code

### DIFF
--- a/src/SparkFun_SCD4x_Arduino_Library.h
+++ b/src/SparkFun_SCD4x_Arduino_Library.h
@@ -28,6 +28,10 @@
 
 // #define USE_TEENSY3_I2C_LIB
 
+// Uncomment the next #define to EXclude any debug logging from the code, by default debug logging code will be included
+
+// #define SCD4x_ENABLE_DEBUGLOG 0 // OFF/disabled/excluded on demand
+
 #include "Arduino.h"
 #ifdef USE_TEENSY3_I2C_LIB
 #include <i2c_t3.h>

--- a/src/SparkFun_SCD4x_Arduino_Library.h
+++ b/src/SparkFun_SCD4x_Arduino_Library.h
@@ -35,6 +35,15 @@
 #include <Wire.h>
 #endif
 
+//Enable/disable including debug log (to allow saving some space)
+#ifndef SCD4x_ENABLE_DEBUGLOG
+  #if defined(LIBRARIES_NO_LOG) && LIBRARIES_NO_LOG
+    #define SCD4x_ENABLE_DEBUGLOG 0 // OFF/disabled/excluded on demand
+  #else
+    #define SCD4x_ENABLE_DEBUGLOG 1 // ON/enabled/included by default
+  #endif
+#endif
+
 //The default I2C address for the SCD4x is 0x62.
 #define SCD4x_ADDRESS 0x62
 
@@ -196,8 +205,10 @@ private:
   //Convert serial number digit to ASCII
   char convertHexToASCII(uint8_t digit);
 
+  #if SCD4x_ENABLE_DEBUGLOG
   //Debug
   Stream *_debugPort;          //The stream to send debug messages to if enabled. Usually Serial.
   boolean _printDebug = false; //Flag to print debugging variables
+  #endif // if SCD4x_ENABLE_DEBUGLOG
 };
 #endif


### PR DESCRIPTION
Resolves #3 

Optionally leave out the debug logging (and the somewhat long flash-string messages) to reduce sketch size (ca. 2.5 kB gained).

Usage:
- Uncomment this line `// #define SCD4x_ENABLE_DEBUGLOG 0` (ca. line 33 in `SparkFun_SCD4x_Arduino_Library.h`) to disable the debug logging
- or: Add `-DLIBRARIES_NO_LOG=1` to your compiler build flags to disable debug logging
- or: Use library as before to keep the debug logging in 😃 